### PR TITLE
Catching empty result which does not parse into json

### DIFF
--- a/plugins/modules/fetch_secrets.py
+++ b/plugins/modules/fetch_secrets.py
@@ -196,8 +196,8 @@ def run_module():
 
     except Exception as e:
         module.fail_json(msg=str(e), **result)
-
-    logout(server_base_url, token)
+    finally:
+        logout(server_base_url, token)
 
     module.exit_json(**result)
 

--- a/plugins/modules/fetch_secrets.py
+++ b/plugins/modules/fetch_secrets.py
@@ -129,8 +129,11 @@ def get_vault_entries(server_base_url, token, vault_id):
     }
 
     response = requests.get(vault_url, headers=vault_headers)
-    result = response.json()
-    return result.get('data', [])
+    try:
+        result = response.json()
+        return result.get('data', [])
+    except ValueError:
+        return {}
 
 def run_module():
     module_args = dict(


### PR DESCRIPTION
some entries come back empty, not able to parse as json.
this results in:
```
TASK [Fetch secrets] ************************************************************************************
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Expecting value: line 1 column 1 (char 0)"}
```

The PR returns an empty dict.